### PR TITLE
Changes to react-dart-uniflow reflecting changes Persistent and React libraries

### DIFF
--- a/labs/architecture-examples/react-dart-uniflow/pubspec.yaml
+++ b/labs/architecture-examples/react-dart-uniflow/pubspec.yaml
@@ -3,6 +3,5 @@ version: 1.0.0
 description: TodoMVC built with Dart. Simple, vanilla Dart.
 dependencies:
   browser: any
-  persistent:
-    git: https://github.com/vacuumlabs/persistent.git
   react: any
+  vacuum_persistent: any

--- a/labs/architecture-examples/react-dart-uniflow/web/dart/app.dart
+++ b/labs/architecture-examples/react-dart-uniflow/web/dart/app.dart
@@ -2,7 +2,7 @@ library todomvc;
 
 import 'dispatcher.dart';
 import 'package:react/react_client.dart';
-import 'package:persistent/persistent.dart';
+import 'package:vacuum_persistent/persistent.dart';
 
 // This is an example of unidirectional flow architecture of a SPA based on React
 // and persistent data structures.

--- a/labs/architecture-examples/react-dart-uniflow/web/dart/components.dart
+++ b/labs/architecture-examples/react-dart-uniflow/web/dart/components.dart
@@ -2,7 +2,7 @@ library todomvc.components;
 
 import 'dart:html';
 import 'package:react/react.dart';
-import 'package:persistent/persistent.dart';
+import 'package:vacuum_persistent/persistent.dart';
 import 'dispatcher.dart';
 
 // React components are defined here. They can assign events to the elements, but these
@@ -90,7 +90,7 @@ var mainComponent = registerComponent(() => new Main());
 class TodoList extends _Component {
   render() {
     return
-      ul({'id': 'todo-list'}, (value['list'] as PersistentVector).toList().reversed.map((PersistentMap item) =>
+      ul({'id': 'todo-list'}, (value['list'] as PVec).toList().reversed.map((PMap item) =>
         todoListItemComponent({'value': persist({
           'item': item,
           'isEditing': value['edit'] == item['id']})})));
@@ -100,7 +100,7 @@ var todoListComponent = registerComponent(() => new TodoList());
 
 
 class TodoListItem extends _Component {
-  PersistentMap get item => value['item'];
+  PMap get item => value['item'];
 
   Map getInitialState() {
     return {'value': item['text']};

--- a/labs/architecture-examples/react-dart-uniflow/web/dart/data.dart
+++ b/labs/architecture-examples/react-dart-uniflow/web/dart/data.dart
@@ -1,6 +1,6 @@
 library todomvc.data;
 
-import 'package:persistent/persistent.dart';
+import 'package:vacuum_persistent/persistent.dart';
 
 // Our global application data class. I added some methods to it, which allows to
 // work conveniently with deep persistent structures, like 'get-in' or 'update-in' functions
@@ -20,8 +20,8 @@ import 'package:persistent/persistent.dart';
 //   {'foo': [{'bar': 'bla', 'bar2': 'bla3'}]}
 //
 class Data {
-  PersistentMap _value;
-  PersistentMap get value => _value;
+  PMap _value;
+  PMap get value => _value;
 
   Data(this._value);
 
@@ -38,16 +38,16 @@ class Data {
 
      var nextPart = (path as List).removeAt(0);
      if ((path as List).isEmpty) {
-       if (d is PersistentVector) {
-         // There is no efficient way to remove an item from PersistentVector so far, unfortunately
+       if (d is PVec) {
+         // There is no efficient way to remove an item from PVec so far, unfortunately
          var list = d.toList().getRange(0, nextPart).toList()..addAll(d.toList().getRange(nextPart + 1, d.length));
-         d = new PersistentVector.from(list);
+         d = new PVec.from(list);
        } else {
          d = d.delete(nextPart);
        }
      } else {
        var newVal = remove(path, d[nextPart]);
-       if (d is PersistentVector) {
+       if (d is PVec) {
          d = d.set(nextPart, newVal);
        } else {
          d = d.insert(nextPart, newVal);
@@ -64,7 +64,7 @@ class Data {
     if (path is String) {
       path = [path];
     }
-    (path as List).add((get(path) as PersistentVector).length);
+    (path as List).add((get(path) as PVec).length);
     _value = insertIn(value, path, v);
   }
 

--- a/labs/architecture-examples/react-dart-uniflow/web/dart/dispatcher.dart
+++ b/labs/architecture-examples/react-dart-uniflow/web/dart/dispatcher.dart
@@ -9,7 +9,7 @@ import 'models/item.dart';
 // Rerenders the whole view, from top to bottom. We always rerender the whole thing, letting
 // React decide what should be updated and what should not down the road.
 void rerender() {
-  renderComponent(todoAppComponent({'value': appData.value}), querySelector('#todoapp'));
+  render(todoAppComponent({'value': appData.value}), querySelector('#todoapp'));
 }
 
 // Our main and only entry for all the events from the view. View sends them in a form of maps,

--- a/labs/architecture-examples/react-dart-uniflow/web/dart/models/item.dart
+++ b/labs/architecture-examples/react-dart-uniflow/web/dart/models/item.dart
@@ -1,7 +1,7 @@
 library todomvc.models.item;
 
 import '../data.dart';
-import 'package:persistent/persistent.dart';
+import 'package:vacuum_persistent/persistent.dart';
 
 class Item {
   final int _id;
@@ -22,21 +22,21 @@ class Item {
 
   static void create(String value) {
     appData.update("autoincrement", appData.get("autoincrement") + 1);
-    var map = new PersistentMap.fromMap({'text': value, 'id': appData.get("autoincrement"), 'isCompleted': false});
+    var map = new PMap.fromMap({'text': value, 'id': appData.get("autoincrement"), 'isCompleted': false});
     appData.add("list", map);
   }
 
   static void toggleAll() {
-    PersistentVector list = appData.get("list");
-    var areAllCompleted = list.every((PersistentMap item) => item['isCompleted']);
-    list.forEach((PersistentMap item) {
+    PVec list = appData.get("list");
+    var areAllCompleted = list.every((PMap item) => item['isCompleted']);
+    list.forEach((PMap item) {
       var id = item['id'];
       new Item(id).toggle(!areAllCompleted);
     });
   }
 
   static void clearCompleted() {
-    appData.get("list").forEach((PersistentMap item) {
+    appData.get("list").forEach((PMap item) {
       new Item(item['id']).toggle(false);
     });
   }


### PR DESCRIPTION
Changes to react-dart-uniflow to reflect changes in dependent libraries

persistent -> vacuum_persistent (hosted); 
PersistentVector -> PVec; 
PersistentMap -> PMap; 
renderComponent() -> render()

As a learner I am hoping this makes sense...
